### PR TITLE
[1/2] Add new method for determining whether to show block option

### DIFF
--- a/src/com/android/contacts/common/util/BlockContactHelper.java
+++ b/src/com/android/contacts/common/util/BlockContactHelper.java
@@ -112,6 +112,11 @@ public class BlockContactHelper {
         return mIsBlacklisted;
     }
 
+    public boolean canBlockContact(Context context) {
+        boolean isBlacklistEnabled = BlacklistUtils.isBlacklistEnabled(context);
+        return isBlacklistEnabled && mBlockRequest != null && mBlockRequest != BlockRequest.EMPTY;
+    }
+
     public String getLookupProviderName() {
         if (mIsProviderInitialized) {
             return mLookupProvider.getDisplayName();


### PR DESCRIPTION
BlockRequests only work on certain data types.
Phone numbers are currently the only type supported.
It doesn't make sense to give block action to something that won't get blocked.

Ticket CD-461

Change-Id: If3f50f1ee0a4cee2d17fcc33b94eea75099ae561