### PR TITLE
Add valid number checks for block menu item

### DIFF
--- a/src/com/android/contacts/common/model/BlockRequest.java
+++ b/src/com/android/contacts/common/model/BlockRequest.java
@@ -59,7 +59,8 @@ public class BlockRequest {
     }
 
     public static BlockRequest createFrom(Context context, String phoneNumber) {
-        if (TextUtils.isEmpty(phoneNumber)) {
+        if (TextUtils.isEmpty(phoneNumber) || !PhoneNumberHelper.isValidNumber(context,
+                phoneNumber, null)) {
             return EMPTY;
         }
 


### PR DESCRIPTION
CallStatsDetailActivity crashes upon block contacts synced from
InCall plugins without valid phone numbers.

Change-Id: Ic921fc16bf7a1911c7f0ebf3aed33decc54cc67f
Issue-id: FEIJ-992