### PR TITLE
[1/4] Add cancel callback for BlockContactDialog

### DIFF
--- a/src/com/android/contacts/common/activity/BlockContactActivity.java
+++ b/src/com/android/contacts/common/activity/BlockContactActivity.java
@@ -60,6 +60,11 @@ public class BlockContactActivity extends Activity implements BlockContactDialog
     }
 
     @Override
+    public void onBlockCancelled() {
+        // STUB
+    }
+
+    @Override
     public void onBlockSelected(boolean notifyLookupProvider) {
         mBlockContactHelper.blockContactAsync(notifyLookupProvider);
     }

--- a/src/com/android/contacts/common/activity/fragment/BlockContactDialogFragment.java
+++ b/src/com/android/contacts/common/activity/fragment/BlockContactDialogFragment.java
@@ -123,14 +123,14 @@ public class BlockContactDialogFragment extends DialogFragment
     }
 
     @Override
-    public void onCancel(DialogInterface dialog) {}
+    public void onCancel(DialogInterface dialog) {
+        Callbacks callback = getCallback();
+        if (callback != null) {
+            callback.onBlockCancelled();
+        }
+    }
 
-    @Override
-    public void onClick(DialogInterface dialog, int which) {
-        boolean mCheckboxStatus = mNotifyProviderCheckBox.isChecked();
-        // determine if a Callback is present
-        // priority is given to a TargetFragment if one is set
-        // otherwise the host activity is chosen, if it adheres to the Callbacks interface
+    public Callbacks getCallback() {
         Callbacks callback = null;
         Fragment targetFragment = getTargetFragment();
         if (targetFragment != null) {
@@ -143,7 +143,16 @@ public class BlockContactDialogFragment extends DialogFragment
                 callback = (Callbacks) parentActivity;
             }
         }
+        return callback;
+    }
 
+    @Override
+    public void onClick(DialogInterface dialog, int which) {
+        boolean mCheckboxStatus = mNotifyProviderCheckBox.isChecked();
+        // determine if a Callback is present
+        // priority is given to a TargetFragment if one is set
+        // otherwise the host activity is chosen, if it adheres to the Callbacks interface
+        Callbacks callback = getCallback();
         if (callback != null) {
             if (mLaunchMode == BLOCK_MODE) {
                 callback.onBlockSelected(mCheckboxStatus);
@@ -169,5 +178,10 @@ public class BlockContactDialogFragment extends DialogFragment
          *                             LookupProvider of the unblock
          */
         void onUnblockSelected(boolean notifyLookupProvider);
+
+        /**
+         * Callback noting that the user cancelled the blocking of the contact
+         */
+        void onBlockCancelled();
     }
 }


### PR DESCRIPTION
Some ui elements need to refresh themselves when the dialog
is cancelled. This allows them to do that.

Change-Id: Ifa4646d799727cf864f560eaeca5fee95c546c36
Ticket: CYNGNOS-3111