### PR TITLE
Fix crash when block incoming call without caller ID

### DIFF
--- a/src/com/android/contacts/common/activity/BlockContactActivity.java
+++ b/src/com/android/contacts/common/activity/BlockContactActivity.java
@@ -79,6 +79,8 @@ public class BlockContactActivity extends Activity implements BlockContactDialog
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        mBlockContactHelper.destroy();
+        if (mBlockContactHelper != null) {
+            mBlockContactHelper.destroy();
+        }
     }
 }


### PR DESCRIPTION
If caller phone number is empty, finish will be called
directly in onCreate without mBlockContactHelper being
created. Causing null object refernece in onDestory
function. Add a null checking to guard that.

CYNGNOS-3262 HAM-1455

Change-Id: I4e73fc52c815feec723e5b56ffee06375619a109
(cherry picked from commit 60a394e091bea89416f8cb89047385df7da9f4d4)