### PR TITLE
Enable support for groups in External contacts accounts

### DIFF
--- a/src/com/android/contacts/common/model/account/ExternalAccountType.java
+++ b/src/com/android/contacts/common/model/account/ExternalAccountType.java
@@ -246,6 +246,11 @@ public class ExternalAccountType extends BaseAccountType {
         return mHasEditSchema;
     }
 
+    @Override
+    public boolean isGroupMembershipEditable() {
+        return true;
+    }
+
     /**
      * Whether this account type has the android.provider.CONTACTS_STRUCTURE metadata xml.
      */


### PR DESCRIPTION
This permits use with DavDroid and other external providers and lets external
contacts providers also do groups (as there's nothing otherwise stopping them)

Change-Id: I6b8133c03a1a647e52b32007a4891051c2c57999
(cherry picked from commit 0cbd4e195ec22f31c0d4be21e325a1673fa9fa99)
(cherry picked from commit 2e3d2e9c9b4aa3b38df8b638aa0864f9370a5b65)